### PR TITLE
Fixed the limit for a non-existent rank

### DIFF
--- a/lua/ulx/modules/sv_unolimited.lua
+++ b/lua/ulx/modules/sv_unolimited.lua
@@ -32,7 +32,7 @@ if ULib ~= nil then
 		-- Check if Game is Singleplayer and Group is Set
 		if not game.SinglePlayer() or unoLimited.groups[ group ] ~= nil then
 			-- Get Limit Multiplier
-			local mult = tonumber( unoLimited.groups[ group ] )				
+			local mult = tonumber( unoLimited.groups[ group ] ) or 0				
 
 			-- Check if Limits was Disabled
 			if mult == -1 then


### PR DESCRIPTION
The server starts and in admin menu a new rank is created. It is issued to the player, but by that time the system has not yet received a new rank in the list of limits. What causes the error. Now, if a rank was created during the gameplay and given to the player, but until it is configured in UnoLimited, the player has a limit of 0